### PR TITLE
Fix - issue code and summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed parsing regex for Toggl entries.
+- Fixed duration formatting when the duration is higher than one day.
+
 ## [1.2.0] - 2023-10-13
 
 ### Added

--- a/src/Client/Toggl/TogglClient.php
+++ b/src/Client/Toggl/TogglClient.php
@@ -106,7 +106,7 @@ final class TogglClient implements ReadClientInterface
      */
     private function createEntry(array $entry, array $filters, LoggerInterface $logger): ?Entry
     {
-        $parsed = false !== (bool) preg_match('/^(?<ISSUE>[a-zA-Z]+-\d+)( +)?(?<DESCRIPTION>.*)?$/', $entry['description'], $m);
+        $parsed = false !== (bool) preg_match('/^(?<ISSUE>[a-zA-Z\-\d]+)( +)?(?<DESCRIPTION>.*)?$/', $entry['description'], $m);
         $stop = $entry['stop'] ?? null;
 
         if (!$parsed || !isset($m['ISSUE'], $m['DESCRIPTION'])) {

--- a/src/Helper/DurationFormatter.php
+++ b/src/Helper/DurationFormatter.php
@@ -27,6 +27,11 @@ final class DurationFormatter
 
         $interval = $start->diff($end);
         $hours = $interval->h;
+
+        if (false !== $interval->days) {
+            $hours += 24 * $interval->days;
+        }
+
         $minutes = $interval->i;
 
         return 0 < $hours ? ($hours . 'h ' . $minutes . 'm') : ($minutes . 'm');


### PR DESCRIPTION
- Fixed parsing regex for Toggl entries.
- Fixed duration formatting when the duration is higher than one day (the problem was found in the durations summary).