### PR TITLE
Prune mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-07-14
+
+### Added
+
+- Added option `--prune`.
+
 ## [1.2.1] - 2024-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -61,16 +61,17 @@ $ docker exec -it t2j-app bin/console sync --start <START_DATE> --end <END_DATE>
 
 ## Available Options
 
-| Option                   | Type    | Description                                                                                                                                                                                                       |
-|--------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--start`                | String  | Accepts datetime strings - absolute or relative, default: `yesterday`                                                                                                                                             |
-| `--end`                  | String  | Accepts datetime strings - absolute or relative, default: `yesterday`                                                                                                                                             |
-| `--group-by-day`         | Boolean | Group all daily entries into one (per issue)                                                                                                                                                                      |
-| `--append`               | Boolean | All entries will be added without creating a diff. Will cause duplicates if the command is run multiple times on the same day                                                                                     |
-| `--rounding`             | Integer | All entries will be rounded to up the given minutes [2-60]                                                                                                                                                        |
+| Option                   | Type    | Description                                                                                                                                                                                                      |
+|--------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--start`                | String  | Accepts datetime strings - absolute or relative, default: `yesterday`                                                                                                                                            |
+| `--end`                  | String  | Accepts datetime strings - absolute or relative, default: `yesterday`                                                                                                                                            |
+| `--group-by-day`         | Boolean | Group all daily entries into one (per issue)                                                                                                                                                                     |
+| `--append`               | Boolean | All entries will be added without creating a diff. Will cause duplicates if the command is run multiple times on the same day                                                                                    |
+| `--prune`                | Boolean | All entries will be synchronized by default, however existing entries in JIRA for issues that do not exist in Toggl will be removed. This option can not be combined with the `--append` option                  |
+| `--rounding`             | Integer | All entries will be rounded to up the given minutes [2-60]                                                                                                                                                       |
 | `--filter`               | String  | Filter in the format "filterName=filterValue" that entries must meet for synchronization. Multiple values can be declared, between filters with the same name is OR, between filters with different names is AND. |
-| `--dry-run`              | Boolean | Displays only change set and summary tables but do not synchronize anything                                                                                                                                       |
-| `-n`, `--no-interaction` | Boolean | Do not ask any interactive question, suitable for scheduled commands, etc.                                                                                                                                        |
+| `--dry-run`              | Boolean | Displays only change set and summary tables but do not synchronize anything                                                                                                                                      |
+| `-n`, `--no-interaction` | Boolean | Do not ask any interactive question, suitable for scheduled commands, etc.                                                                                                                                       |
 
 ## Description format
 

--- a/src/Client/Jira/JiraClient.php
+++ b/src/Client/Jira/JiraClient.php
@@ -303,7 +303,7 @@ final class JiraClient implements WriteClientInterface
                 } while ($startAt < $total);
             } catch (Throwable $e) {
                 throw new AbortException(
-                    '[jira] Can not fetch all issue codes.' . $e->getMessage(),
+                    '[jira] Can not fetch all issue codes. ' . $e->getMessage(),
                     0,
                     $e,
                 );

--- a/src/Client/Jira/JiraClient.php
+++ b/src/Client/Jira/JiraClient.php
@@ -53,14 +53,18 @@ final class JiraClient implements WriteClientInterface
     /**
      * @throws AbortException|Exception
      */
-    public function listEntries(Range $range, array $issueCodes, LoggerInterface $logger): array
+    public function listEntries(Range $range, ?array $issueCodes, LoggerInterface $logger): array
     {
-        if (empty($issueCodes)) {
+        if (is_array($issueCodes) && empty($issueCodes)) {
             throw new AbortException('[jira] Please provide an array of issue codes.');
         }
 
         $entries = [];
         $accountId = $this->fetchAccountId();
+
+        if (null === $issueCodes) {
+            $issueCodes = $this->fetchAllIssueCodes($range);
+        }
 
         foreach ($issueCodes as $issueCode) {
             $workLogs = $this->fetchWorkLog($issueCode, $range, $logger);
@@ -259,6 +263,58 @@ final class JiraClient implements WriteClientInterface
         assert(null === $issueTitle || is_string($issueTitle));
 
         return $issueTitle;
+    }
+
+    /**
+     * @return list<string>
+     * @throws AbortException
+     */
+    private function fetchAllIssueCodes(Range $range): array
+    {
+        $issueCodes = $this->hitCache('all-issue-codes-' . $range->start->format(DateTimeInterface::ATOM) . '-' . $range->end->format(DateTimeInterface::ATOM), function () use ($range) {
+            $jql = sprintf(
+                'worklogAuthor = currentUser() AND worklogDate >= %d AND worklogDate <= %d',
+                ($range->start->getTimestamp() - 1) * 1000,
+                ($range->end->getTimestamp() + 1) * 1000,
+            );
+            $startAt = 0;
+            $issueCodes = [];
+
+            try {
+                do {
+                    $response = $this->client->request('GET', $this->websiteUrl . '/search', [
+                        'headers' => $this->createHeaders(),
+                        'query' => [
+                            'jql' => $jql,
+                            'fields' => 'key',
+                            'startAt' => $startAt,
+                            'maxResults' => 100,
+                        ],
+                    ]);
+
+                    $data = json_decode($response->getBody()->getContents(), false, 512, JSON_THROW_ON_ERROR);
+
+                    foreach ($data->issues ?? [] as $issue) {
+                        $issueCodes[] = $issue->key;
+                    }
+
+                    $total = $data->total;
+                    $startAt += $data->maxResults;
+                } while ($startAt < $total);
+            } catch (Throwable $e) {
+                throw new AbortException(
+                    '[jira] Can not fetch all issue codes.' . $e->getMessage(),
+                    0,
+                    $e,
+                );
+            }
+
+            return $issueCodes;
+        });
+
+        assert(is_array($issueCodes));
+
+        return $issueCodes;
     }
 
     /**

--- a/src/Client/Toggl/TogglClient.php
+++ b/src/Client/Toggl/TogglClient.php
@@ -109,7 +109,7 @@ final class TogglClient implements ReadClientInterface
         $parsed = false !== (bool) preg_match('/^(?<ISSUE>[a-zA-Z\-\d]+)( +)?(?<DESCRIPTION>.*)?$/', $entry['description'], $m);
         $stop = $entry['stop'] ?? null;
 
-        if (!$parsed || !isset($m['ISSUE'], $m['DESCRIPTION'])) {
+        if (!$parsed) {
             $logger->warning(sprintf(
                 '[toggl] Can not synchronize entry "%s" from %s - %s. The entry description is not properly formatted.',
                 $entry['description'],
@@ -158,7 +158,7 @@ final class TogglClient implements ReadClientInterface
             $entryEntity = new Entry(
                 (string) $entry['id'],
                 $issueCode,
-                trim($m['DESCRIPTION']),
+                trim($m['DESCRIPTION'] ?? ''),
                 (new DateTimeImmutable($entry['start']))->setTimezone(new DateTimeZone('UTC')),
                 $entry['duration'],
             );

--- a/src/Client/WriteClientInterface.php
+++ b/src/Client/WriteClientInterface.php
@@ -12,12 +12,12 @@ use Psr\Log\LoggerInterface;
 interface WriteClientInterface
 {
     /**
-     * @param array<string> $issueCodes
+     * @param array<string>|null $issueCodes
      *
      * @return array<Entry>
      * @throws AbortException
      */
-    public function listEntries(Range $range, array $issueCodes, LoggerInterface $logger): array;
+    public function listEntries(Range $range, ?array $issueCodes, LoggerInterface $logger): array;
 
     public function createEntry(Entry $entry, LoggerInterface $logger): bool;
 

--- a/src/Console/Command/SyncCommand.php
+++ b/src/Console/Command/SyncCommand.php
@@ -43,7 +43,8 @@ final class SyncCommand extends Command
             ->addOption('start', null, InputOption::VALUE_REQUIRED, 'Start date. The value must be a valid datetime string (absolute or relative)', 'yesterday')
             ->addOption('end', null, InputOption::VALUE_REQUIRED, 'End date. The value must be a valid datetime string (absolute or relative)', 'yesterday')
             ->addOption('group-by-day', null, InputOption::VALUE_NONE, 'Enables "group by day" group mode')
-            ->addOption('append', null, InputOption::VALUE_NONE, 'Enables "append" sync mode')
+            ->addOption('append', null, InputOption::VALUE_NONE, 'Enables "append" sync mode. All entries will be added without creating a diff. Will cause duplicates if the command is run multiple times on the same day')
+            ->addOption('prune', null, InputOption::VALUE_NONE, 'Enabled "prune" sync mode. All entries will be synchronized by default, however existing entries in JIRA for issues that do not exist in Toggl will be removed.')
             ->addOption('rounding', null, InputOption::VALUE_OPTIONAL, 'Rounds entries to up the minutes. The value must be an integer in the range [2-60]')
             ->addOption('filter', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'One or more filters in format "filter_name=filter_value". Only entries that matches filters will be processed.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Dumps only change set without persisting it in the JIRA.');
@@ -60,6 +61,14 @@ final class SyncCommand extends Command
         $rounding = $input->getOption('rounding');
         $filters = $input->getOption('filter');
         assert(is_array($filters));
+        $append = (bool) $input->getOption('append');
+        $prune = (bool) $input->getOption('prune');
+
+        if ($append && $prune) {
+            $logger->error('Options `--append` and `--prune` can not be used together.');
+
+            return Command::FAILURE;
+        }
 
         $options = new Options(
             range: new Range(
@@ -67,7 +76,7 @@ final class SyncCommand extends Command
                 (new DateTimeImmutable($input->getOption('end'), new DateTimeZone('UTC')))->setTime(23, 59, 59),
             ),
             groupMode: $input->getOption('group-by-day') ? GroupMode::GROUP_BY_DAY : GroupMode::DEFAULT,
-            syncMode: $input->getOption('append') ? SyncMode::APPEND : SyncMode::DEFAULT,
+            syncMode: $append ? SyncMode::APPEND : ($prune ? SyncMode::PRUNE : SyncMode::DEFAULT),
             rounding: null !== $rounding ? new Rounding((int) $rounding) : null,
             filters: array_map(
                 static fn (string $filter): Filter => Filter::fromString($filter),

--- a/src/Console/Helper/DataSetDumper.php
+++ b/src/Console/Helper/DataSetDumper.php
@@ -21,7 +21,7 @@ use function array_sum;
 use function usort;
 
 /**
- * @phpstan-type SortedDataSet array<string, array{day: DateTimeImmutable, source?: array<Entry>, destination?: array<Entry>, inserts?: array<Entry>, updates?: array<Entry>, deletes?: array<Entry>, intersections?: array<Entry>}>
+ * @phpstan-type SortedDataSet array<int, array{day: DateTimeImmutable, source?: array<Entry>, destination?: array<Entry>, inserts?: array<Entry>, updates?: array<Entry>, deletes?: array<Entry>, intersections?: array<Entry>}>
  */
 final class DataSetDumper
 {

--- a/src/Synchronization/Synchronizer.php
+++ b/src/Synchronization/Synchronizer.php
@@ -8,6 +8,7 @@ use App\Client\ReadClientInterface;
 use App\Client\WriteClientInterface;
 use App\Exception\AbortException;
 use App\ValueObject\Entry;
+use App\ValueObject\SyncMode;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -64,14 +65,15 @@ final class Synchronizer implements SynchronizerInterface
     private function createDataSet(Options $options, LoggerInterface $logger): DataSet
     {
         $sourceEntries = $this->readClient->listEntries($options->range, $options->filters, $logger);
+        $prune = SyncMode::PRUNE === $options->syncMode;
 
-        if (empty($sourceEntries)) {
+        if (!$prune && empty($sourceEntries)) {
             $logger->info('Nothing to synchronize.');
 
             return DataSet::empty();
         }
 
-        $issuesCodes = !empty($options->issueCodes) ? $options->issueCodes : array_unique(array_map(static fn (Entry $entry): string => $entry->issue, $sourceEntries));
+        $issuesCodes = !$prune ? array_unique(array_map(static fn (Entry $entry): string => $entry->issue, $sourceEntries)) : null;
         $destinationEntries = $this->writeClient->listEntries($options->range, $issuesCodes, $logger);
 
         $diff = $this->diffGenerator->diff($sourceEntries, $destinationEntries, $options->groupMode, $options->syncMode, $options->rounding);

--- a/src/ValueObject/SyncMode.php
+++ b/src/ValueObject/SyncMode.php
@@ -8,4 +8,5 @@ enum SyncMode
 {
     case DEFAULT;
     case APPEND;
+    case PRUNE;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new `--prune` command-line option to remove existing Jira entries for issues not present in Toggl during synchronization.
  * Added a new synchronization mode for pruning entries, selectable via the `--prune` flag.

* **Bug Fixes**
  * Prevented simultaneous use of `--append` and `--prune` options, ensuring clear sync behavior.

* **Documentation**
  * Updated documentation to describe the new `--prune` option and clarify option usage.

* **Other Improvements**
  * Enhanced synchronization logic for increased flexibility and improved handling of empty source entries in prune mode.
  * Improved issue code fetching to automatically retrieve all relevant Jira issues when pruning.
  * Simplified entry description parsing to prevent errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->